### PR TITLE
feat: use raw pointer and volatile methods 

### DIFF
--- a/src/api/control.rs
+++ b/src/api/control.rs
@@ -65,6 +65,24 @@ pub fn max_iter(max_iter: u32) {
 }
 
 /// Accept the originating transaction and commit any changes the hook made
+///
+/// # Example
+///
+/// You can use a byte string to return a message
+/// ```
+/// accept(b"accept.rs: Finished.", line!().into());
+/// ```
+///
+/// You can also return any forms of bytes, like:
+/// ```
+/// let txn_hash = match emit(&xrp_payment_txn) {
+///     Ok(hash) => hash,
+///     Err(err) => {
+///         rollback(b"could not emit xrp payment txn", err.into());
+///     }
+/// };
+/// accept(&txn_hash, 0);
+/// ```
 #[inline(always)]
 pub fn accept(msg: &[u8], error_code: i64) -> ! {
     unsafe {
@@ -74,6 +92,11 @@ pub fn accept(msg: &[u8], error_code: i64) -> ! {
 }
 
 /// Reject the originating transaction and discard any changes the hook made
+///
+/// # Example
+/// ```
+/// rollback(b"encountered a problem", -1)
+/// ```
 #[inline(always)]
 pub fn rollback(msg: &[u8], error_code: i64) -> ! {
     unsafe {

--- a/src/api/etxn.rs
+++ b/src/api/etxn.rs
@@ -33,6 +33,12 @@ pub fn etxn_fee_base(tx_blob: &[u8]) -> Result<u64> {
     unsafe { c::etxn_fee_base(tx_blob.as_ptr() as u32, tx_blob.len() as u32).into() }
 }
 
+/// Estimate the required fee for a txn to be emitted successfully
+#[inline(always)]
+pub fn etxn_fee_base_from_ptr(tx_blob_ptr: *mut MaybeUninit<u8>, tx_blob_len: u32) -> Result<u64> {
+    unsafe { c::etxn_fee_base(tx_blob_ptr as u32, tx_blob_len).into() }
+}
+
 /// Generate a 32 byte nonce for use in an emitted transaction
 #[inline(always)]
 pub fn etxn_nonce() -> Result<[u8; NONCE_LEN]> {
@@ -66,6 +72,26 @@ pub fn emit(tx: &[u8]) -> Result<[u8; HASH_LEN]> {
                 HASH_LEN as u32,
                 tx.as_ptr() as u32,
                 tx.len() as u32,
+            )
+            .into()
+        };
+
+        result
+    };
+
+    init_buffer_mut(func)
+}
+
+/// Emit a new transaction from the hook and return the 32-bytes long txn hash
+#[inline(always)]
+pub fn emit_from_ptr(tx_ptr: *const u8, tx_len: u32) -> Result<[u8; HASH_LEN]> {
+    let func = |buffer_mut_ptr: *mut MaybeUninit<u8>| {
+        let result: Result<u64> = unsafe {
+            c::emit(
+                buffer_mut_ptr as u32,
+                HASH_LEN as u32,
+                tx_ptr as u32,
+                tx_len,
             )
             .into()
         };

--- a/src/api/float.rs
+++ b/src/api/float.rs
@@ -7,7 +7,8 @@ use crate::c;
 
 use super::*;
 
-/// XFL floating point number
+/// Abstraction of [XFL floating point numbers](https://github.com/XRPLF/XRPL-Standards/discussions/39).
+/// The struct is overloaded with basic numeric operations, such as addition, subtraction, multiplication, division, and negation. Comparison operators are also implemented.
 #[derive(Clone, Copy)]
 pub struct XFL(pub i64);
 
@@ -38,9 +39,106 @@ pub fn float_sto(
 
 impl XFL {
     /// Create a new XFL number from an exponent and mantissa
+    ///
+    /// # Example
+    /// ```
+    /// let plus_1000 = XFL::new(-12, 1000000000000000).unwrap_line_number();
+    /// ```
     #[inline(always)]
     pub fn new(exponent: i32, mantissa: i64) -> Result<Self> {
         Self::from_verified_i64(unsafe { c::float_set(exponent, mantissa) })
+    }
+
+    /// Read a serialized XFL amount into an XFL
+    #[inline(always)]
+    pub fn from_sto(serialized_xfl: &[u8; XFL_LEN]) -> Result<Self> {
+        Self::from_verified_i64(unsafe {
+            c::float_sto_set(serialized_xfl.as_ptr() as _, XFL_LEN as _)
+        })
+    }
+
+    /// Return the number 1 represented in an XFL enclosing number
+    ///
+    /// # Example
+    /// ```
+    /// let half = XFL::one().mulratio(false, 1, 2)
+    /// ```
+    #[inline(always)]
+    pub fn one() -> Self {
+        // Instead of using c::float_one, we use the computed enclosing
+        // value directly.
+        XFL(6089866696204910592)
+    }
+
+    /// Convert an XFL floating point into an integer (floor).
+    /// The behavior is as follows:
+    /// 1. Left shift (multiply by 10) the XFL by the number of specified decimal places
+    /// 2. Convert the resulting XFL to an integer, discarding any remainder
+    /// 3. Return the integer
+    ///
+    /// # Example
+    /// ```
+    /// let approx_pi = XFL::new(-15, 3140000000000000).unwrap_line_number();
+    ///
+    /// if 3 != approx_pi.to_int64(0, false).unwrap_line_number() {
+    ///     rollback(b"incorect rounding", line!().into());
+    /// }
+    /// ```
+    #[inline(always)]
+    pub fn to_int64(&self, decimal_places: u32, is_absolute: bool) -> Result<i64> {
+        let result = unsafe { c::float_int(self.0, decimal_places, is_absolute as _) };
+
+        match result {
+            res if res >= 0 => Ok(res),
+            _ => Err(Error::from_code(result as _)),
+        }
+    }
+
+    /// Get the exponent of an XFL enclosing number
+    ///
+    /// # Example
+    /// ```
+    /// let plus_998 = XFL::new(-13, 9980000000000000).unwrap_line_number();
+    ///
+    /// if plus_998.exponent() != -13 {
+    ///     rollback(b"exponent incorrect", line!().into());
+    /// }
+    /// ```
+    #[inline(always)]
+    pub fn exponent(&self) -> i64 {
+        (((self.0 >> 54 & 0xFF) as i32) - 97).into()
+    }
+
+    /// Get the exponent of an XFL enclosing number
+    ///
+    /// # Example
+    /// ```
+    /// let plus_998 = XFL::new(-13, 9980000000000000).unwrap_line_number();
+    ///
+    /// if plus_998.mantissa() != 9980000000000000 {
+    ///     rollback(b"mantissa incorrect", line!().into());
+    /// }
+    /// ```
+    #[inline(always)]
+    pub fn mantissa(&self) -> i64 {
+        unsafe { c::float_mantissa(self.0) }
+    }
+
+    /// Multiply an XFL floating point by a non-XFL numerator and denominator
+    ///
+    /// # Example
+    /// ```
+    /// if XFL::one().mulratio(false, 1, 2).unwrap_line_number()
+    ///     != XFL::one().mulratio(false, 5, 10).unwrap_line_number()
+    /// {
+    ///     rollback(b"", line!().into());
+    /// }
+    /// ```
+    #[inline(always)]
+    pub fn mulratio(&self, round_up: bool, numerator: u32, denominator: u32) -> Result<XFL> {
+        Self::from_verified_i64(unsafe {
+            c::float_mulratio(self.0, round_up as _, numerator, denominator)
+        })
     }
 
     // Create a new XFL number from a verified i64, that is,
@@ -59,57 +157,6 @@ impl XFL {
             source if source >= 0 => Ok(XFL(source)),
             _ => Err(Error::from_code(source as _)),
         }
-    }
-
-    /// Read a serialized XFL amount into an XFL
-    #[inline(always)]
-    pub fn from_sto(serialized_xfl: &[u8; XFL_LEN]) -> Result<Self> {
-        Self::from_verified_i64(unsafe {
-            c::float_sto_set(serialized_xfl.as_ptr() as _, XFL_LEN as _)
-        })
-    }
-
-    /// Return the number 1 represented in an XFL enclosing number
-    #[inline(always)]
-    pub fn one() -> Self {
-        // Instead of using c::float_one, we use the computed enclosing
-        // value directly.
-        XFL(6089866696204910592)
-    }
-
-    /// Convert an XFL floating point into an integer (floor).
-    /// The behavior is as follows:
-    /// 1. Left shift (multiply by 10) the XFL by the number of specified decimal places
-    /// 2. Convert the resulting XFL to an integer, discarding any remainder
-    /// 3. Return the integer
-    #[inline(always)]
-    pub fn to_int64(&self, decimal_places: u32, is_absolute: bool) -> Result<i64> {
-        let result = unsafe { c::float_int(self.0, decimal_places, is_absolute as _) };
-
-        match result {
-            res if res >= 0 => Ok(res),
-            _ => Err(Error::from_code(result as _)),
-        }
-    }
-
-    /// Get the exponent of an XFL enclosing number
-    #[inline(always)]
-    pub fn exponent(&self) -> i64 {
-        (((self.0 >> 54 & 0xFF) as i32) - 97).into()
-    }
-
-    /// Get the exponent of an XFL enclosing number
-    #[inline(always)]
-    pub fn mantissa(&self) -> i64 {
-        unsafe { c::float_mantissa(self.0) }
-    }
-
-    /// Multiply an XFL floating point by a non-XFL numerator and denominator
-    #[inline(always)]
-    pub fn mulratio(&self, round_up: bool, numerator: u32, denominator: u32) -> Result<XFL> {
-        Self::from_verified_i64(unsafe {
-            c::float_mulratio(self.0, round_up as _, numerator, denominator)
-        })
     }
 }
 

--- a/src/api/hook.rs
+++ b/src/api/hook.rs
@@ -4,6 +4,18 @@ use super::*;
 use crate::c;
 
 /// Retreive the 20 byte Account ID the Hook is executing on
+///
+/// # Example
+/// ```
+/// let hook_account = match hook_account() {
+///     Ok(acc) => acc,
+///     Err(err) => {
+///         rollback(b"hook_account.rs: hook_account() failed.", err.into());
+///     }
+/// };
+///
+/// accept(&hook_account, 0);
+/// ```
 #[inline(always)]
 pub fn hook_account() -> Result<[u8; ACC_ID_LEN]> {
     let func = |buffer_mut_ptr: *mut MaybeUninit<u8>| {
@@ -17,6 +29,14 @@ pub fn hook_account() -> Result<[u8; ACC_ID_LEN]> {
 }
 
 /// Retrieve the parameter value for a named hook parameter
+///
+/// # Example
+/// ```
+/// match hook_param::<HOOK_PARAM_LEN>(b"param test") {
+///     Ok(param) => accept(&param, 0),
+///     Err(err) => rollback(b"cannot find hook param", err.into()),
+/// }
+/// ```
 #[inline(always)]
 pub fn hook_param<const HOOK_PARAM_LEN: usize>(
     parameter_name: &[u8],

--- a/src/api/state.rs
+++ b/src/api/state.rs
@@ -7,6 +7,29 @@ use super::*;
 /// Retrieve the data pointed to by a Hook State key and write it to an output buffer
 /// The keys are always 32 bytes (unsigned 256 bit integer) and the values are variable
 /// length with a maximum size determined by validator voting, at time of writing 128 bytes.
+///
+/// # Example
+/// ```
+/// #[inline(always)]
+/// fn get_count(key: &[u8; ACC_ID_LEN]) -> u64 {
+///     match state::<STATE_VALUE_LEN>(key.as_ref()) {
+///         Ok(data) => u64::from_be_bytes(data),
+///         Err(_err) => {
+///             rollback(b"could not get count state", -1);
+///         }
+///     }
+/// }
+///
+/// #[inline(always)]
+/// fn set_count(count: u64, key: &[u8; ACC_ID_LEN]) {
+///     match state_set(count.to_be_bytes().as_ref(), key.as_ref()) {
+///         Ok(_) => {}
+///         Err(_) => {
+///             rollback(b"could not set state", -1);
+///         }
+///     };
+/// }
+/// ```
 #[inline(always)]
 pub fn state<const STATE_VALUE_LEN: usize>(key: &[u8]) -> Result<[u8; STATE_VALUE_LEN]>
 where
@@ -29,6 +52,30 @@ where
 }
 
 /// Set the Hook State for a given key and value
+///
+/// # Example
+/// ```
+/// #[inline(always)]
+/// fn get_count(key: &[u8; ACC_ID_LEN]) -> u64 {
+///     match state::<STATE_VALUE_LEN>(key.as_ref()) {
+///         Ok(data) => u64::from_be_bytes(data),
+///         Err(_err) => {
+///             rollback(b"could not get count state", -1);
+///         }
+///     }
+/// }
+///
+/// #[inline(always)]
+/// fn set_count(count: u64, key: &[u8; ACC_ID_LEN]) {
+///     match state_set(count.to_be_bytes().as_ref(), key.as_ref()) {
+///         Ok(_) => {}
+///         Err(_) => {
+///             rollback(b"could not set state", -1);
+///         }
+///     };
+/// }
+/// ```
+
 #[inline(always)]
 pub fn state_set(data: &[u8], key: &[u8]) -> Result<u64> {
     unsafe {

--- a/src/api/trace.rs
+++ b/src/api/trace.rs
@@ -5,6 +5,17 @@ use crate::c;
 use super::*;
 
 /// Write the contents of a buffer to the XRPLD trace log
+///
+/// # Example
+///
+/// The first argument will be shown on the left side of the log
+/// and the second argument will be shown on the right side of the log.
+///
+/// Usually you would want to use the first argument to specify what the
+/// data is and the second argument to specify the data itself.
+/// ```
+/// let _ = trace(b"left", b"right", DataRepr::AsUTF8);
+/// ```
 #[inline(always)]
 pub fn trace(msg: &[u8], data: &[u8], data_repr: DataRepr) -> Result<u64> {
     let res = unsafe {
@@ -29,6 +40,11 @@ pub fn trace_slot(msg: &[u8], slot: u32) -> Result<u64> {
 }
 
 /// Write an integer to the XRPLD trace log
+///
+/// # Example
+/// ```
+/// let _ = trace_num(b"my number", 42);
+/// ```
 #[inline(always)]
 pub fn trace_num(msg: &[u8], number: i64) -> Result<u64> {
     let res = unsafe { c::trace_num(msg.as_ptr() as u32, size_of_val(msg) as u32, number) };
@@ -37,6 +53,11 @@ pub fn trace_num(msg: &[u8], number: i64) -> Result<u64> {
 }
 
 /// Write a XFL float to the XRPLD trace log
+///
+/// # Example
+/// ```
+/// let _ = trace_float(b"my float", XFL(42.0));
+/// ```
 #[inline(always)]
 pub fn trace_float(msg: &[u8], float: XFL) -> Result<u64> {
     let res = unsafe { c::trace_float(msg.as_ptr() as u32, size_of_val(msg) as u32, float.0) };

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -247,4 +247,13 @@ export class TestUtils {
 
     return false;
   }
+
+  static async afterPromise<T>(
+    promise: Promise<T>,
+    promiseCb: (result: T) => void
+  ): Promise<T> {
+    const result = await promise;
+    promiseCb(result);
+    return result;
+  }
 }


### PR DESCRIPTION
This PR marks an important point where we begin to properly use raw pointers. This reduces the binary size significantly, actually almost to the point where it has similar size to the wasm produced from the C file of an equivalent logic.